### PR TITLE
Update dc-running.md

### DIFF
--- a/docs/products/ex-commandstation/dc-running.md
+++ b/docs/products/ex-commandstation/dc-running.md
@@ -1,28 +1,34 @@
-# Running a DC layout
+# Running a Legacy DC layout
 
 Using a DCC-EX Command Station to run a DC layout provides a number of advantages over conventional DC systems.
 
-- All Wifi and connected throttles will operate the same for DC and DCC
-- Momentum can be defined for acceleration and braking
-- Multiple DC blocks can be independently controlled and reconfigured to allow crossing between blocks and polarity reversal
-- EXRAIL automation can be used to run trains, create routes, switch block relays, control signals, manage reversing loops etcetera
-- PWM Frequency can be adjusted to suit your locos and/or reduce noise with a touch of the F29-F31 keys
-- It is possible to run parts of the layout with DC and other parts with DCC at the same time (But do not leave a DC loco on a track configured for DCC)
+- All Wifi and wired connected throttles will operate the same for DC and DCC locos using Cab road numbers 'loco addresses' from 1 to 10239.
+- Using this range of Cab locoid addresses you can assign any DC district/track any locoid to run in that DC district, i.e # 2.
+- Multiple DC Districts (maximum four on EX-CSB1 & maximum eight on Mega2560 system) can be independently controlled and reconfigured to allow crossing between districts and polarity reversal.
+- Any DC District can be further subdivided into smaller blocks and energized or powerd via turnout points and or SPDT switches If desired, i.e. staging or fiddle yard..  
+- Momentum of a loco can be defined in number of seconds of travel for acceleration and braking distances.
+- EXRAIL automation can be used to run trains, create routes, switch block relays, control signals, control accessory special effects, manage reversing loops, etcetera.
+- Pulse Width Modulation PWM 'Frequency' can be adjusted to suit your locos and/or reduce DC noise with a touch of the throttles function F29-F31 button.
+- With our Track Manager features it is possible to run parts of the layout with DC and other parts with DCC at the same time, and through a single wifi throttle controller with both DC & DCC locos shown & controlled at the same time.  (But do not leave a DC loco sitting idle on a track configured for DCC).
+- No DC legacy Transformers are used, only standard Laptop battery supplies from 12vdc to 24vdc and from 2A, 5A or 10Amps are used depending on your scale requirements.
+- Note: Each Power District section must have 'dual insulated rail joiners' between each track section that connect and travel between one districts to another.
 
-## Basic funtionality
+## Basic functionality
 
-The command station has Track Manager commands that can change each track output to DC with appropriate polarity.  By associating a numeric locoid (1..10239 the same range as DCC) with each track output the command station accepts incoming DCC throttle commands (Or EXRAIL automation commands) for that locoid and converts it to a DC output on every track output with the same locoid.
+The DCC-EX command station has TrackManager commands that can change each district/track output to DC with appropriate polarity.  By associating a numeric road number as locoid (1..10239 the same range as DCC) with each district/track output the command station accepts incoming DCC throttle commands (Or EXRAIL automation commands) for that locoid and converts it to a DC output on every district/track output with the same locoid.
 
-The throttles or EXRAIL are unaware that they are driving a DC track and so any DCC Throttle such as Engine Driver that can talk to DCC-EX will work for DC. In effect, in DC mode, the throttle drives the track compared with DCC mode where the throttle drives the loco.
+The throttles or EXRAIL are unaware that they are driving a DC districts/tracks and so any DCC Throttle such as Engine Driver that can talk to DCC-EX will work for DC. In effect, in DC mode, the throttle drives the track compared with DCC mode where the throttle drives the loco.
 
-Although the CSB-1 can be switched to DC operation by commands from the throttle (Engine Driver has a Track Manager panel to help do this) it is generally easier, for a fully DC layout, to configure it so that it starts up in the desired mode.
+Although the EX-CSB1 can be switched to DC operation by commands from the throttle (Engine Driver has a Track Manager panel to help do this) it is generally easier, for a fully DC layout, to configure it so that it starts up in the desired mode of DC Districts.
 
-Warning: The sometimes-suggested technique of using a DCC decoder to output to a DC track instead of a motor is NOT RECOMMENDED as most decoders are not tolerant of a short between the motor outputs. This means a common track short could destroy an expensive decoder.
+Warning: The sometimes-alternate suggested technique of using a DCC decoder to output directly to a DC track instead internally to the loco motor is NOT RECOMMENDED as most decoders are not tolerant of a short between the motor outputs. This means a common track short could damage an expensive decoder.
 
 ## Configuring Default Outputs
 
 The normal configuration method for DCC-EX Command Station is to use EXRAIL to define things like:
 
+- What type of Districts/tracks do I want to use DC, DCC or both
+- What are the locoids or Cab# defined in the Roster for throttles to see and use.
 - What turnouts or signals you have and how they are electronically driven
 - What happens at startup
 - What routes can a throttle set
@@ -31,9 +37,11 @@ The normal configuration method for DCC-EX Command Station is to use EXRAIL to d
 
 all of which apply equally to DC operation, plus:
 
-- How track blocks are set for DC and which locoid thay are mapped to
+- How track Districts are set for DC and which locoid addresses they are mapped to
 
-To start this you need to follow the [Installer process described here](/installer/overview.md) and create an AUTOSTART section in your myAutomation.h file to set the track manager options suitable for your layout:
+To start this you need to follow the [Installer process described here](/installer/overview.md) and create an AUTOSTART section in your myAutomation.h file to set the track manager options suitable for your layout.
+
+Two districts A & B are set to DC mode and initially powered On:
 
 ```cpp
 AUTOSTART 
@@ -48,11 +56,11 @@ AUTOSTART
 
 This sequence will run as the command station starts up it will
 
-- associate locoid 1 with track A and switch it to DC.
-- associate locoid 2 with track B and switch it to DC.
-- turn track power on. No power will be seen on the track until a throttle is used, but unless you SET_POWER ON the track will never receive power.
+- associate locoid 1 with district track A and switch it to DC.
+- associate locoid 2 with district track B and switch it to DC.
+- turn track power on. No power will be seen on the tracks until a throttle is used, but unless you SET_POWER ON the track will never receive power.
 
-Where the command station has 4 or more track outputs, you can also setup tracks C to H as appropriate.
+Where the command station has 4 or more district/track outputs, you can also setup tracks C to D as appropriate using locoid or cab addresses 1 .. 10239.
 
 ## Switching between tracks
 
@@ -97,7 +105,7 @@ As you get more advanced, the routes can be programmed to happen automatically o
 
 In contrast to DCC, a DC reversing loop must have the polarity to correctly represent the direction of the loco. Thus the loop part will require the polarity to control the direction of the train around the loop.
 while the train is in the loop, the main track leading into the loop must be switched to allow the train to exit the loop and continue back along the track without reversing the locomotive.
-There is no automatic polarity reversing for DC layouts, this must be programmed using EXRAIL to suit the topology of your layout.
+There is no automatic polarity reversing for DC layouts, this must be programmed using EXRAIL track mode DCX using SET_TRACK (B, DCX) to suit the topology of your layout.
 
 ## More blocks
 


### PR DESCRIPTION
First draft update to DC-Running.md

further defined power Districts/tracks versus sub blocks. added detail on assigning DC Districts Cab road numbers as locoid addresses. defined PWM,
 added replacing legacy DC Transformers with laptop battery power supplies.
noted dual insulated nylon rail joiners between district/track sections.

corrected spelling and changed track H to  D

KCSmith