### PR TITLE
remove the navigation sections headings for sections with only 1 page

### DIFF
--- a/docs/contributing/.nav.yml
+++ b/docs/contributing/.nav.yml
@@ -1,5 +1,7 @@
 nav:
-  - Contributing: contributing.md
+  - How You Can Contribute: contributing.md
   - User Journeys: user-journeys.md
   - Release Checklist: release-checklist.md
-  - "*"
+  - Contributing Code: code/contributing-code.md
+  - Contributing Documentation: documentation
+  

--- a/docs/products/.nav.yml
+++ b/docs/products/.nav.yml
@@ -2,12 +2,12 @@ nav:
   - Product List: products.md
   - Getting Started: getting-started.md
   - EX-CommandStation: ex-commandstation
-  - EX-MotorShield8874: ex-motorshield8874
-  - EX-WiFiShield8266: ex-wifishield8266
+  - EX-MotorShield8874: ex-motorshield8874/ex-motorshield8874.md
+  - EX-WiFiShield8266: ex-wifishield8266/ex-wifishield8266.md
   - EX-FastClock: ex-fastclock
-  - EX-IOExpander: ex-ioexpander
-  - EX-Turntable: ex-turntable
+  - EX-IOExpander: ex-ioexpander/ex-ioexpander.md
+  - EX-Turntable: ex-turntable/ex-turntable.md
   - EX-SensorCAM: ex-sensorcam
   - EX-Toolbox: ex-toolbox
-  - EX-WebThrottle: ex-webthrottle
+  - EX-WebThrottle: ex-webthrottle/ex-webthrottle.md
   

--- a/docs/products/ex-webthrottle/ex-webthrottle.md
+++ b/docs/products/ex-webthrottle/ex-webthrottle.md
@@ -1,6 +1,6 @@
 # EX-WebThrottle - Overview
 
-TODO: Split into seperate pages for overview plus installing and using
+==TODO== Split into seperate pages for overview plus installing and using.
 
 [Run EX&#8209;WebThrottle Now](https://dcc-ex.com/WebThrottle-EX/){ .md-button .md-button--primary }
 

--- a/docs/reference/serial-commands/serial-command-y_not_in_nav.md
+++ b/docs/reference/serial-commands/serial-command-y_not_in_nav.md
@@ -21,19 +21,19 @@ The DFPlayer device can be used to play pre-recorded sounds from an onboard SD-c
 
 See the [DFPlayer page](/products/ex-commandstation/accessories/various-devices/dfplayer/dfplayer.md) for more information.
 
-## Command(s)
+## Commands
 
-* ``<y «vpin» EQ «eq»>`` Set sound EQ
 * ``<y «vpin» FOLDER «folder»>`` Switch to sound track folder
-* ``<y «vpin» PAUSE>`` Pause sound
-* ``<y «vpin» PLAY «tracknumber» «volume»>`` Play sound track with volume
 * ``<y «vpin» PLAY «tracknumber»>`` Play sound track with default volume
-* ``<y «vpin» REPEAT «tracknumber» «volume»>`` Repeat sound track with volume
+* ``<y «vpin» PLAY «tracknumber» «volume»>`` Play sound track with volume
 * ``<y «vpin» REPEAT «tracknumber»>`` Repeat sound track with default volume
-* ``<y «vpin» RESET>`` Reset sound module
-* ``<y «vpin» RESUME>`` Resume sound
+* ``<y «vpin» REPEAT «tracknumber» «volume»>`` Repeat sound track with volume
+* ``<y «vpin» PAUSE>`` Pause playing sound
+* ``<y «vpin» RESUME>`` Resume playing sound
 * ``<y «vpin» STOP>`` Stop playing sound
-* ``<y «vpin» VOL «volume»>`` Set sound volume
+* ``<y «vpin» VOL «volume»>`` Set default volume
+* ``<y «vpin» EQ «eq»>`` Set sound EQ
+* ``<y «vpin» RESET>`` Reset sound module
 
 ## Parameters
 
@@ -49,7 +49,7 @@ See the [DFPlayer page](/products/ex-commandstation/accessories/various-devices/
 * **tracknumber**: track/file on the SD Card to play
 * **volume**: Volume to play the track at (``0``-``30``)
 
-## Response
+## Responses
 
 ==TODO==
 

--- a/docs/throttles/.nav.yml
+++ b/docs/throttles/.nav.yml
@@ -1,4 +1,6 @@
 nav:
   - Throttle Lists: throttles.md
+  - EX-WebThrottle: ex-webthrottle.md
   - Engine Driver: engine-driver.md
   - ThrottleCard: throttlecard.md
+  

--- a/docs/throttles/ex-webthrottle.md
+++ b/docs/throttles/ex-webthrottle.md
@@ -1,0 +1,5 @@
+# EX-WebThrottle
+
+**EX-WebThrottle** is our in-house developed throttle (controller) that runs in a web browser and can connect to the **EX-CommandStation** directly through the USB port of a computer.
+
+See the [EX-WebThrottle - Overview](/products/ex-webthrottle/ex-webthrottle.md) page for more information.

--- a/docs/throttles/throttles.md
+++ b/docs/throttles/throttles.md
@@ -1,6 +1,8 @@
 # Throttles and Other Controllers
 
-The following are lists of the Throttle apps and devices that are known to work with **EX-Commandstations**.  There may be others.
+Any app or device that can use the WiThrottle Protocol or the DCC-EX Native/Serial Protocol should be able to connect to an **EX-CommandStation** to control you trains.
+
+The following are lists of the Throttle/Controller apps and devices that are known to work with **EX-CommandStations**.  There may be others.
 
 ----
 
@@ -70,14 +72,16 @@ See also: Arduino/ESP32 DCC-EX Native command library - [DCCEXProtocol](https://
 
 ## Throttles - By Communication technology
 
-A **EX-CommandStation** can use a number of different technologies to communicate with a throttle. While each technology has advantages and disadvantages, none is substantially better than the others.
+A **EX-CommandStation** can use different technologies to communicate with a throttle. While each technology has advantages and disadvantages, none is substantially better than the others for simply running locos.
+
+However the DCC-EX Native/Serial commands provive a significant numnber of extra capabilities including CV Programming, though not all apps and devices that use the Serial Commands make use of these features
 
 ### General
 
-- WiThrottle Server, Web Server, DCC-EX Native Commands Explained
-- Connect WiFi Throttle via USB
+- [WiThrottle Server, DCC-EX Native Commands Explained](/reference/withrottle-vs-native-protocol_not_in_nav.md)
+- Connect WiFi Throttle via USB ==TODO==
 
-### DCC-EX Native Commands
+### DCC-EX Native/Serial Commands
 
 - [EX-WebThrottle](../products/ex-webthrottle/ex-webthrottle.md) (Windows, MacOS, Linux) *recommended*
 - [Engine Driver](./engine-driver.md) (Android) *recommended*


### PR DESCRIPTION
- remove the navigation sections headings for sections with only 1 page
- odds and ends on the throttle page
